### PR TITLE
[messages] Add a push and display only one message.

### DIFF
--- a/src/messages/index.js
+++ b/src/messages/index.js
@@ -1,8 +1,8 @@
 import {connect} from 'react-redux';
 import {removeMessage} from './messages-actions';
-import {messagesSelector} from './messages-reducer';
+import {messageToDisplaySelector} from './messages-reducer';
 import MessageCenter from './messages-component';
 export default connect(
-  messagesSelector,
+  messageToDisplaySelector,
   {deleteMessage: removeMessage}
 )(MessageCenter);

--- a/src/messages/messages-reducer.js
+++ b/src/messages/messages-reducer.js
@@ -4,6 +4,10 @@ export function messagesSelector(state){
   return {messages: state.messages};
 }
 
+export function messageToDisplaySelector(state){
+  return {messages: state.messages.length > 0 ? state.messages.slice(0,1) : []};
+}
+
 function messageCenterReducer(state = [], action){
   switch (action.type) {
     case PUSH_MESSAGE:


### PR DESCRIPTION
The problem was to be _compatible_ with material spec and display only one message. When this message is erased it reprocess the state as it deletes a message.

With a suberb tricks, only one message is display

:hocho:  `=> Just change the selector <=` :hocho: 

