### PR TITLE
[Translation] Adding option to disable the separator

### DIFF
--- a/src/translation/index.js
+++ b/src/translation/index.js
@@ -1,13 +1,14 @@
 
 
-export const intializeTranslation = (i18nextProject, language = 'fr-FR', resources = []) => {
+export const intializeTranslation = (i18nextProject, language = 'fr-FR', resources = [], stringSeparator = ':') => {
     i18nextProject.init({
         lng: language,
         resources: {
             [language]: {
                 translation: resources.reduce((acc, newValue) => ({...acc, ...newValue, focus: {...acc.focus, ...newValue.focus}}))
             }
-        }
+        },
+        nsSeparator: stringSeparator
     }, (err, t) => {
         console.info('[FOCUS-APPLICATION] Translation initialized !');
     });


### PR DESCRIPTION
## [Translation] Adding option to disable the separator

### Description

I've added an option to disable the default string separator  which is set to ":". We can now edit it or disable it on the initialization by adding a third parameter on the `initializeTranslation` function.
For example to disable the separator, we do it this way : 

```
// IMPORTS
import {intializeTranslation} from 'focus-application/translation';
import i18n from 'i18next';
import focusTranslation from 'focus-components/translation/resources/fr-FR';
import frTranslation from './config/translations/fr';

// FOCUS INITIALIZATION
intializeTranslation(i18n, 'fr-FR', [focusTranslation, frTranslation], false);
```

> Fixes https://github.com/get-focus/focus-components/issues/98